### PR TITLE
feat: add support for dynamic labeling and container name

### DIFF
--- a/crd/nimble.ivaltryek.github.com.yaml
+++ b/crd/nimble.ivaltryek.github.com.yaml
@@ -26,6 +26,12 @@ spec:
                     image:
                       type: string
                     replicas:
-                       type: integer
-                       format: int32 
-                       default: 1
+                      type: integer
+                      format: int32 
+                      default: 1
+                    labels:
+                      type: object
+                      additionalProperties:
+                        type: string
+                  required:
+                    - labels

--- a/examples/simple-deployment.yaml
+++ b/examples/simple-deployment.yaml
@@ -6,3 +6,6 @@ metadata:
 spec:
   deployment:
     image: nginx:stable
+    labels:
+      app: nginx
+      env: test

--- a/src/common/helper.rs
+++ b/src/common/helper.rs
@@ -1,0 +1,11 @@
+use std::collections::BTreeMap;
+
+pub fn json_obj_to_btreemap(json_object: serde_json::Value) -> BTreeMap<String, String> {
+    let mut labels_tree: BTreeMap<String, String> = BTreeMap::new();
+
+    for (key, value) in json_object.as_object().unwrap() {
+        labels_tree.insert(key.to_owned(), value.as_str().unwrap().to_string());
+    }
+
+    labels_tree
+}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,0 +1,1 @@
+pub mod helper;

--- a/src/crds/nimble.rs
+++ b/src/crds/nimble.rs
@@ -19,4 +19,5 @@ pub struct NimbleSpec {
 pub struct DeploySpec {
     pub image: String,
     pub replicas: i32,
+    pub labels: serde_json::Value,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+mod common;
 mod controllers;
 mod crds;
 use kube::{Api, Client};


### PR DESCRIPTION
- fixes #3 :heavy_check_mark:  Container names are dynamic based upon whatever is provided in `Nimble` manifest's `metadata`

- fixes #2 :heavy_check_mark:  Deployments's `MatchLabels` are dynamic based upon whatever is provided in `Nimble` manifest's `spec.deployment.labels`